### PR TITLE
Added CustomAnalyzer and Utilities

### DIFF
--- a/smells-like-lucene-it/src/main/java/tcd/analyzers/MyCustomAnalyzer.java
+++ b/smells-like-lucene-it/src/main/java/tcd/analyzers/MyCustomAnalyzer.java
@@ -1,0 +1,68 @@
+package tcd.analyzers;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.Analyzer.TokenStreamComponents;
+import org.apache.lucene.analysis.LowerCaseFilter;
+import org.apache.lucene.analysis.StopFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.analysis.en.EnglishPossessiveFilter;
+import org.apache.lucene.analysis.en.KStemFilter;
+import org.apache.lucene.analysis.en.PorterStemFilter;
+import org.apache.lucene.analysis.miscellaneous.CapitalizationFilter;
+import org.apache.lucene.analysis.shingle.ShingleFilter;
+import org.apache.lucene.analysis.snowball.SnowballFilter;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+
+// Adapted from https://www.baeldung.com/lucene-analyzers
+
+//Usage:
+// MyCustomAnalyzer snowballAnalyzer = new MyCustomAnalyzer("Snowball"); Creates an English analyzer with the "Snowball" stemming algorithm.
+//We can easily add more string inputs if we want to add different token filters, but from my experimentation the EnglishAnalyzer config works best.
+
+//Default (with no input) is Porter stemming
+//"Snowball" uses the Snoball stemming algorithm
+//"KStem" uses the K-Stem stemming algorithm
+
+public class MyCustomAnalyzer extends Analyzer {
+	
+	private String stemmer;
+	
+	public MyCustomAnalyzer() {		
+		super();
+		this.stemmer = "Porter";			
+	}
+		
+	public MyCustomAnalyzer(String stem_name) {		
+		super();
+		this.stemmer = stem_name;		
+	}
+    
+	@Override
+	protected TokenStreamComponents createComponents(String fieldName) {
+        StandardTokenizer src = new StandardTokenizer();
+        TokenStream result = new LowerCaseFilter(src);
+        result = new EnglishPossessiveFilter(result);
+        result = new StopFilter(result,  EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
+              
+        if(stemmer == "Porter") {
+        	result = new PorterStemFilter(result);
+        	System.out.println("Using Porter Stemming");
+        	
+        } else if(stemmer == "KStem") {
+        	result = new KStemFilter(result);
+        	System.out.println("Using KStem Stemming");
+        	
+        } else if (stemmer == "Snowball") {
+        	
+        	result = new SnowballFilter(result, "English");
+        	System.out.println("Using Snowball Stemming");
+        }
+
+        //result = new ShingleFilter(result);
+        //result = new CapitalizationFilter(result);
+        return new TokenStreamComponents(src, result);
+    }
+}
+

--- a/smells-like-lucene-it/src/main/java/tcd/utils/CommonTermsLowFreqBoostQuery.java
+++ b/smells-like-lucene-it/src/main/java/tcd/utils/CommonTermsLowFreqBoostQuery.java
@@ -1,0 +1,97 @@
+package tcd.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermStates;
+import org.apache.lucene.queries.CommonTermsQuery;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.BooleanClause.Occur;
+
+//Custom query class, finds low-frequency (rare) terms in the query and adds boosts to them, increasing their supposed relevance.
+//Don't worry about intergrating now.
+
+public class CommonTermsLowFreqBoostQuery extends CommonTermsQuery {
+	
+	
+	public CommonTermsLowFreqBoostQuery(Occur highFreqOccur, Occur lowFreqOccur, float maxTermFrequency,  float customLowFreqBoost) {
+		
+		//Allows for the manipulation of the lowFreqBoost protected variables from the parent class
+		super(highFreqOccur, lowFreqOccur, maxTermFrequency);
+		this.lowFreqBoost = customLowFreqBoost;
+
+	}
+
+	public void setLowFreqBoost(float customLowFreqBoost) {
+		
+		this.lowFreqBoost = customLowFreqBoost;
+		
+	}
+	
+	protected Query buildQuery(final int maxDoc,
+                             final TermStates[] contextArray, final Term[] queryTerms) {
+    List<Query> lowFreqQueries = new ArrayList<>();
+    List<Query> highFreqQueries = new ArrayList<>();
+    for (int i = 0; i < queryTerms.length; i++) {
+      TermStates termStates = contextArray[i];
+      if (termStates == null) {
+        lowFreqQueries.add(newTermQuery(queryTerms[i], null));
+      } else {
+        if ((maxTermFrequency >= 1f && termStates.docFreq() > maxTermFrequency)
+            || (termStates.docFreq() > (int) Math.ceil(maxTermFrequency
+                * (float) maxDoc))) {
+          highFreqQueries
+              .add(newTermQuery(queryTerms[i], termStates));
+        } else {
+          lowFreqQueries.add(newTermQuery(queryTerms[i], termStates));
+        }
+      }
+    }
+    final int numLowFreqClauses = lowFreqQueries.size();
+    final int numHighFreqClauses = highFreqQueries.size();
+    Occur lowFreqOccur = this.lowFreqOccur;
+    Occur highFreqOccur = this.highFreqOccur;
+    int lowFreqMinShouldMatch = 0;
+    int highFreqMinShouldMatch = 0;
+    if (lowFreqOccur == Occur.SHOULD && numLowFreqClauses > 0) {
+      lowFreqMinShouldMatch = calcLowFreqMinimumNumberShouldMatch(numLowFreqClauses);
+    }
+    if (highFreqOccur == Occur.SHOULD && numHighFreqClauses > 0) {
+      highFreqMinShouldMatch = calcHighFreqMinimumNumberShouldMatch(numHighFreqClauses);
+    }
+    if (lowFreqQueries.isEmpty()) {
+      /*
+       * if lowFreq is empty we rewrite the high freq terms in a conjunction to
+       * prevent slow queries.
+       */
+      if (highFreqMinShouldMatch == 0 && highFreqOccur != Occur.MUST) {
+        highFreqOccur = Occur.MUST;
+      }
+    }
+    BooleanQuery.Builder builder = new BooleanQuery.Builder();
+
+    if (lowFreqQueries.isEmpty() == false) {
+      BooleanQuery.Builder lowFreq = new BooleanQuery.Builder();
+      for (Query query : lowFreqQueries) {
+        lowFreq.add(query, lowFreqOccur);
+      }
+      lowFreq.setMinimumNumberShouldMatch(lowFreqMinShouldMatch);
+      Query lowFreqQuery = lowFreq.build();
+      builder.add(new BoostQuery(lowFreqQuery, lowFreqBoost), Occur.SHOULD); //Changed to SHOULD from MUST, ensure all terms are used.
+    }
+    if (highFreqQueries.isEmpty() == false) {
+      BooleanQuery.Builder highFreq = new BooleanQuery.Builder();
+      for (Query query : highFreqQueries) {
+        highFreq.add(query, highFreqOccur);
+      }
+      highFreq.setMinimumNumberShouldMatch(highFreqMinShouldMatch);
+      Query highFreqQuery = highFreq.build();
+      builder.add(new BoostQuery(highFreqQuery, highFreqBoost), Occur.SHOULD);
+    }
+    return builder.build();
+  }
+	
+}

--- a/smells-like-lucene-it/src/main/java/tcd/utils/MultiQueryTermExtractor.java
+++ b/smells-like-lucene-it/src/main/java/tcd/utils/MultiQueryTermExtractor.java
@@ -1,0 +1,33 @@
+package tcd.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.lucene.search.Query;
+
+//Takes a multi-field query, and returns the list of terms. Used to push in to the CommonTermsLowFreqBoost query.
+
+public class MultiQueryTermExtractor {
+	
+	public static List<String> extractTerms(Query query) {
+		
+		String temp_queryString = query.toString();		
+		Pattern p = Pattern.compile("t:.*?\\)");
+		Matcher matcher = p.matcher(temp_queryString);
+		
+		List<String> terms = new ArrayList<String>();
+		
+		while (matcher.find()) {
+			
+			terms.add(matcher.group().substring(2, matcher.group().length()-1));
+			
+		}
+		
+		return terms;
+		
+		
+	}
+
+}


### PR DESCRIPTION
Added the CustomAnalyzer class, which can take stemming algorithms as inputs.

Added the "CommonTermsLowFreqBoostQuery" class,  a subclass of the "CommonTermsQuery". Can find rare terms in a query and automatically apply boosts to them.

The "MultiQueryTermExctractor" class is used to parse Multi-field queries in to the CommonTermsLowFreqBoostQuery, but it may not be needed.